### PR TITLE
Fix static setup location

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -298,6 +298,8 @@ Faucet will log to ``/var/log/faucet/faucet.log`` and ``/var/log/faucet/faucet_e
 
 Gauge will log to ``/var/log/faucet/gauge.log`` and ``/var/log/faucet/gauge_exception.log`` by default, this can be changed with the ``GAUGE_LOG`` and ``GAUGE_EXCEPTION_LOG`` environment variables.
 
+If running Faucet in ``virtualenv`` and without specifying the environment variables above, the default log and configuration locations will change to reflect the virtual environment's prefix path. For example, the default Faucet log location will be ``<venv prefix>/var/log/faucet/faucet.log``. The Gauge configuration must still be updated in this case by modifying ``<venv prefix>/etc/ryu/faucet/gauge.conf`` to reflect the location of the configuration file used by Faucet (``<venv prefix>/etc/ryu/faucet/faucet.conf``). When using ``virtualenv``, also create the log directory at its new location, ``<venv prefix>/var/log/ryu/faucet``, rather than the global ``/var/log/ryu/faucet``.
+
 To tell Faucet to reload its configuration file after you've changed it, simply send it a ``SIGHUP``:
 
 ``# pkill -SIGHUP -f "ryu-manager faucet.py"``

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,8 @@ with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme:
         version='1.0',
         packages=['ryu_faucet'],
         package_dir={'ryu_faucet': 'src/ryu_faucet'},
-        data_files=[('/etc/ryu/faucet', ['src/cfg/etc/ryu/faucet/gauge.conf',
-                                         'src/cfg/etc/ryu/faucet/faucet.yaml'])
+        data_files=[('etc/ryu/faucet', ['src/cfg/etc/ryu/faucet/gauge.conf',
+                                        'src/cfg/etc/ryu/faucet/faucet.yaml'])
                     ],
         include_package_data=True,
         install_requires=['ryu', 'pyyaml', 'influxdb', 'ipaddr', 'concurrencytest'],

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 import os
 from os import path
 from setuptools import setup
+import sys
 
 with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme:
     README = readme.read()
@@ -11,14 +12,19 @@ with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme:
     os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__),
                                            os.pardir)))
 
+    data_files_prefix = '/'
+    if (getattr(sys, "real_prefix", sys.prefix) != sys.prefix or
+        getattr(sys, "base_prefix", sys.prefix) != sys.prefix):
+        data_files_prefix = ''
+
     setup(
         name='ryu-faucet',
         version='1.0',
         packages=['ryu_faucet'],
         package_dir={'ryu_faucet': 'src/ryu_faucet'},
-        data_files=[('etc/ryu/faucet', ['src/cfg/etc/ryu/faucet/gauge.conf',
-                                        'src/cfg/etc/ryu/faucet/faucet.yaml'])
-                    ],
+        data_files=[(data_files_prefix + 'etc/ryu/faucet',
+                     ['src/cfg/etc/ryu/faucet/gauge.conf',
+                      'src/cfg/etc/ryu/faucet/faucet.yaml'])],
         include_package_data=True,
         install_requires=['ryu', 'pyyaml', 'influxdb', 'ipaddr', 'concurrencytest'],
         license='Apache License 2.0',

--- a/src/ryu_faucet/org/onfsdn/faucet/faucet.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/faucet.py
@@ -19,12 +19,13 @@ import logging
 from logging.handlers import TimedRotatingFileHandler
 import os
 import signal
+import sys
 
 import ipaddr
 
 from config_parser import dp_parser
 from valve import valve_factory
-from util import kill_on_exception
+from util import kill_on_exception, get_sys_prefix
 
 from ryu.base import app_manager
 from ryu.controller.handler import CONFIG_DISPATCHER
@@ -74,12 +75,14 @@ class Faucet(app_manager.RyuApp):
         # options into ryu apps. Instead I am using the environment variable
         # FAUCET_CONFIG to allow this to be set, if it is not set it will
         # default to valve.yaml
+        sysprefix = get_sys_prefix()
         self.config_file = os.getenv(
-            'FAUCET_CONFIG', '/etc/ryu/faucet/faucet.yaml')
+            'FAUCET_CONFIG', sysprefix + '/etc/ryu/faucet/faucet.yaml')
         self.logfile = os.getenv(
-            'FAUCET_LOG', '/var/log/ryu/faucet/faucet.log')
+            'FAUCET_LOG', sysprefix + '/var/log/ryu/faucet/faucet.log')
         self.exc_logfile = os.getenv(
-            'FAUCET_EXCEPTION_LOG', '/var/log/ryu/faucet/faucet_exception.log')
+            'FAUCET_EXCEPTION_LOG',
+            sysprefix + '/var/log/ryu/faucet/faucet_exception.log')
 
         # Set the signal handler for reloading config file
         signal.signal(signal.SIGHUP, self.signal_handler)

--- a/src/ryu_faucet/org/onfsdn/faucet/gauge.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/gauge.py
@@ -16,11 +16,12 @@
 import time
 import os
 import signal
+import sys
 
 import logging
 from logging.handlers import TimedRotatingFileHandler
 
-from util import kill_on_exception
+from util import kill_on_exception, get_sys_prefix
 
 from ryu.base import app_manager
 from ryu.controller import ofp_event
@@ -53,11 +54,14 @@ class Gauge(app_manager.RyuApp):
 
     def __init__(self, *args, **kwargs):
         super(Gauge, self).__init__(*args, **kwargs)
+        sysprefix = get_sys_prefix()
         self.config_file = os.getenv(
-            'GAUGE_CONFIG', '/etc/ryu/faucet/gauge.conf')
+            'GAUGE_CONFIG', sysprefix + '/etc/ryu/faucet/gauge.conf')
         self.exc_logfile = os.getenv(
-            'GAUGE_EXCEPTION_LOG', '/var/log/ryu/faucet/gauge_exception.log')
-        self.logfile = os.getenv('GAUGE_LOG', '/var/log/ryu/faucet/gauge.log')
+            'GAUGE_EXCEPTION_LOG',
+            sysprefix + '/var/log/ryu/faucet/gauge_exception.log')
+        self.logfile = os.getenv(
+            'GAUGE_LOG', sysprefix + '/var/log/ryu/faucet/gauge.log')
 
         # Setup logging
         self.logger = logging.getLogger(self.logname)

--- a/src/ryu_faucet/org/onfsdn/faucet/util.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/util.py
@@ -16,6 +16,7 @@
 import logging
 import os
 import signal
+import sys
 from functools import wraps
 
 
@@ -63,3 +64,19 @@ def kill_on_exception(logname):
                 os.kill(os.getpid(), signal.SIGKILL)
         return __koe
     return _koe
+
+def get_sys_prefix():
+    """Returns an additional prefix for log and configuration files when used in
+    a virtual environment"""
+
+    # Find the appropriate prefix for config and log file default locations
+    # in case Faucet is run in a virtual environment. virtualenv marks the
+    # original path in sys.real_prefix. If this value exists, and is
+    # different from sys.prefix, then we are most likely running in a
+    # virtualenv. Also check for Py3.3+ pyvenv.
+    sysprefix = ""
+    if (getattr(sys, "real_prefix", sys.prefix) != sys.prefix or
+        getattr(sys, "base_prefix", sys.prefix) != sys.prefix):
+        sysprefix = sys.prefix
+
+    return sysprefix


### PR DESCRIPTION
Resolves #11 by using `sys.prefix` in `setup.py`, `faucet.py`, and `gauge.py` if it detects that Faucet is being installed or run in a virtual envrionment. Any other case keeps the default locations.

Tests were performed in two scenarios: Global installation (currently working and documented method) and installation within a virtual environment created by `virtualenv`. 

* Global Install
  * New Ubuntu 16.04 VM created with prereqs required by Faucet installed globally
    * Required manually installing pip 8.1.2 as ryu 4.5 dependencies fail to install with the default pip 8.1.1 provided by Ubuntu 16.04 (you can see this fail when you build the Faucet Docker.tests container, but ryu is already installed so the test still passes).
  * Faucet installed by using `sudo pip install <faucet_location>`
    * Confirmed configuration files placed in `/etc/ryu/faucet` both before and after changes
  * Replaced default config with simple config for testing with Mininet
  * Confirmed Faucet working by running `sudo ryu-manager $faucet_prefix/ryu_faucet/org/onfsdn/faucet/faucet.py` where `faucet_prefix=$(pip show ryu-faucet | grep ^Location: | awk -e '{print $2}')`
  * Ran `sudo mn --test pingpair --mac --controller remote,<ip>:6633`. Mininet was run in a different VM.
* Virtual Environment Install
  * New Ubuntu 16.04 VM created with prereqs required by Python and `virtualenv` only
    * Used standard system pip 8.1.1 as `virtualenv` automatically installs the latest pip in the created virtual environment.
  * New virtual environment created using `virtualenv ~/faucet-dev/venv` as an unprivileged user
  * Copied Faucet to `~/faucet-dev/faucet`
  * Faucet installed by using `pip install ~/faucet-dev/faucet` inside the activated virtual environment
    * Current master fails as it tries to write to `/etc/ryu/faucet` as an unprivileged user
    * These changes cause install to pass with default config placed in `~/faucet-dev/venv/etc/ryu/faucet/`
  * Confirmed Faucet working by running `ryu-manager ~/faucet-dev/faucet/ryu_faucet/org/onfsdn/faucet/faucet.py` in the activated virtual environment as an unprivileged user. (after changes only)
  * Ran `sudo mn --test pingpair --mac --controller remote,<ip>:6633`. Again, Mininet was run in a different VM. (after changes only)

The full test suite is available at https://github.com/inside-openflow/faucet-vagrant-tests which I put together to test Faucet installations in different environments. It tested more than I described here. 

The only thing I'm unsure about are the changes to the documentation. Also, this is my first pull-request I filed on github. Feedback is appreciated.
