### PR TITLE
Fix dp default hardware

### DIFF
--- a/src/ryu_faucet/org/onfsdn/faucet/dp.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/dp.py
@@ -57,7 +57,7 @@ class DP(Conf):
         # description, strictly informational
         'description': None,
         # The hardware maker (for chosing an openflow driver)
-        'hardware': 'Open_vSwitch',
+        'hardware': 'Open vSwitch',
         # ARP and neighbor timeout (seconds)
         'arp_neighbor_timeout': 500,
         # OF channel log

--- a/src/ryu_faucet/org/onfsdn/faucet/faucet.py
+++ b/src/ryu_faucet/org/onfsdn/faucet/faucet.py
@@ -115,11 +115,11 @@ class Faucet(app_manager.RyuApp):
         self.valves = {}
         for dp in dp_parser(self.config_file, self.logname):
             # pylint: disable=no-member
-            valve = valve_factory(dp)(dp, self.logname)
+            valve = valve_factory(dp)
             if valve is None:
                 self.logger.error('Hardware type not supported for DP: %s' % dp.name)
             else:
-                self.valves[dp.dp_id] = valve
+                self.valves[dp.dp_id] = valve(dp, self.logname)
 
         self.gateway_resolve_request_thread = hub.spawn(
             self.gateway_resolve_request)


### PR DESCRIPTION
Fixes #14, both graceful handling of unknown hardware and making the DP default hardware match SUPPORTED_HARDWARE in valve_factory.

Tests run in Docker built from current onfsdn/master as per README.docker.md (summary):

```
----------------------------------------------------------------------
Ran 28 tests in 691.826s

OK

real    11m32.466s
user    1m12.736s
sys     0m39.736s
========== Running faucet config tests ==========
.............
----------------------------------------------------------------------
Ran 13 tests in 0.768s

OK
```